### PR TITLE
Fix build on x86_64 mac

### DIFF
--- a/s4pd.c
+++ b/s4pd.c
@@ -1,3 +1,6 @@
+#include <stdlib.h>
+#include <unistd.h>
+
 #include "m_pd.h"  
 #include "string.h"
 #include "s7.h"


### PR DESCRIPTION
s4pd doesn't compile without explicitly including system headers `stdlib.h` and `unistd.h`. After this change, just cloning the project and running `make` correctly builds it.